### PR TITLE
Fixes for Issue #14: Calling Circuit.toDot() causes class cast exception

### DIFF
--- a/src/main/kotlin/org/ageseries/libage/sim/electrical/mna/Circuit.kt
+++ b/src/main/kotlin/org/ageseries/libage/sim/electrical/mna/Circuit.kt
@@ -663,7 +663,7 @@ class Circuit {
                     1 -> ":e"
                     else -> ""
                 }
-                val node = it.representative as Node
+                val node = (it.representative as Pin).node ?: throw Exception("This pin has a null Node!")
                 sb.append("\t\"c${System.identityHashCode(cmp)}\"$port -- \"${if(node.isGround) "ground" else "n${node.index}"}\" [shape=box ")
                 when (it.node?.index) {
                     0 -> sb.append("color=red")

--- a/src/main/kotlin/org/ageseries/libage/sim/electrical/mna/Circuit.kt
+++ b/src/main/kotlin/org/ageseries/libage/sim/electrical/mna/Circuit.kt
@@ -663,7 +663,7 @@ class Circuit {
                     1 -> ":e"
                     else -> ""
                 }
-                val node = (it.representative as Pin).node ?: throw Exception("This pin has a null Node!")
+                val node = (it.representative as Pin).node ?: error("This pin has a null Node!")
                 sb.append("\t\"c${System.identityHashCode(cmp)}\"$port -- \"${if(node.isGround) "ground" else "n${node.index}"}\" [shape=box ")
                 when (it.node?.index) {
                     0 -> sb.append("color=red")

--- a/src/test/kotlin/org/eln2/libelectric/sim/electrical/mna/MNATests.kt
+++ b/src/test/kotlin/org/eln2/libelectric/sim/electrical/mna/MNATests.kt
@@ -313,4 +313,25 @@ internal class MNATests {
         assert(r.current > 0.99 && r.current < 1.01)
         assert(vs.current > 0.99 && vs.current < 1.01)
     }
+
+    @Test
+    fun testCircuitDot() {
+        val c = Circuit()
+        val r = Resistor()
+        val vs = VoltageSource()
+
+        c.add(vs, r)
+
+        vs.connect(0, r, 0)
+        vs.connect(1, r, 1)
+        vs.ground(0)
+
+        vs.potential = 10.0
+        r.resistance = 10.0
+
+        c.buildMatrix() // Required to populate nodes, otherwise toDot will crash
+        val output = c.toDot()
+
+        assert(output.length > 1)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/age-series/libage/issues/14 and adds a new test to verify that it is fixed.