### PR TITLE
[wip] Adds ktor+netty-based API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
     implementation("org.apache.commons", "commons-math3", "3.6.1")
     implementation("org.jetbrains:annotations:23.0.0")
 
+    implementation("com.google.code.gson:gson:2.9.0")
+
+    implementation("io.ktor:ktor-server-core:2.0.2")
+    implementation("io.ktor:ktor-server-netty:2.0.2")
+
     testImplementation("org.assertj", "assertj-core", "3.22.0")
     testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.8.2")
     testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.8.2")

--- a/src/main/kotlin/org/ageseries/libage/api/LibageApiResponse.kt
+++ b/src/main/kotlin/org/ageseries/libage/api/LibageApiResponse.kt
@@ -1,0 +1,31 @@
+package org.ageseries.libage.api
+
+import com.google.gson.Gson
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+
+val gson = Gson()
+
+data class LibageApiResponse(val crashed: Boolean, val why: String?, val json: String?, val code: Int) {
+    suspend fun respond(call: ApplicationCall) {
+        call.respondText(ContentType.Application.Json, HttpStatusCode.fromValue(code)) {
+            gson.toJson(
+                mapOf(
+                    Pair("crashed", crashed),
+                    Pair("why", why),
+                    Pair("result", json)
+                )
+            )
+        }
+    }
+}
+
+suspend fun ApplicationCall.libageApiResponse(provider: suspend () -> String?) {
+    try {
+        val output = provider.invoke()
+        LibageApiResponse(false, null, output, 200).respond(this)
+    } catch (e: Exception) {
+        LibageApiResponse(true, e.stackTraceToString(), null, 500).respond(this)
+    }
+}

--- a/src/main/kotlin/org/ageseries/libage/api/Server.kt
+++ b/src/main/kotlin/org/ageseries/libage/api/Server.kt
@@ -1,0 +1,56 @@
+package org.ageseries.libage.api
+
+import com.google.gson.Gson
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.ageseries.libage.sim.electrical.mna.Circuit
+import org.ageseries.libage.sim.electrical.mna.component.Component
+import org.ageseries.libage.sim.electrical.mna.component.Resistor
+import org.ageseries.libage.sim.electrical.mna.component.VoltageSource
+import java.util.*
+import kotlin.collections.MutableList
+import kotlin.collections.mutableListOf
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+
+data class CircuitBundle(var circuit: Circuit, var components: MutableList<Component>)
+
+val circuits = mutableMapOf<UUID, CircuitBundle>()
+
+fun loadTestCircuits() {
+    val c = Circuit()
+    val r = Resistor()
+    val vs = VoltageSource()
+
+    c.add(vs, r)
+
+    vs.connect(0, r, 0)
+    vs.connect(1, r, 1)
+    vs.ground(0)
+
+    vs.potential = 10.0
+    r.resistance = 10.0
+
+    circuits[UUID.randomUUID()] = CircuitBundle(c, mutableListOf(r, vs))
+}
+
+fun main() {
+    loadTestCircuits()
+
+    embeddedServer(Netty, port = 8080) {
+        routing {
+            get("/") {
+                call.respondText("libage api endpoint")
+            }
+            get("/circuits.json") {
+
+                call.libageApiResponse {
+                    gson.toJson(circuits)
+                }
+            }
+        }
+    }.start(wait = true)
+}


### PR DESCRIPTION
This is a WIP to add a Ktor + Netty API to libage.

Ideally, it would have a few different API endpoints such as:

* `/` - get basic information about the API, perhaps version info for libage
* `/circuits.json`
* `/circuit/add` - add a circuit
* `/circuit/step` - step a circuit (possibly with some more information in the request such as a number of steps/time of steps)
* `/circuit/fetch` - get circuit solve values
* `/circuit/delete` - delete a circuit
* Some kind of editing API for a circuit. This would require being able to modify connectivity as well. Perhaps for a later version?

The actual format is not set in stone yet, but there's some ideas floating around. I want to be able to use this from within code primarily, so knowing if there are logical errors and such for error handling would be helpful. eg, singular matrices, invalid connectivity, etc. I also currently catch sim side errors and throw those back with a stack trace but we could disable that for production unless debugging is enabled.